### PR TITLE
Add keywords to desktop file

### DIFF
--- a/qesteidutil.desktop
+++ b/qesteidutil.desktop
@@ -4,6 +4,10 @@ Type=Application
 Name=ID-card Utility
 Name[et]=ID-kaardi haldusvahend
 Name[ru]=Oбсуживание ID-карты
+
+Keywords=ID-card;Utility;
+Keywords[et_EE]=ID-kaart;Haldusvahend;
+
 Exec=qesteidutil %F
 Icon=qesteidutil
 Terminal=false


### PR DESCRIPTION
Add English and Estonian keywords to desktop file. Keywords in desktop file gives us more "stars" or credibility in gnome software center. Since I don't speak Russian I could not add them :(