### PR TITLE
Fix misspelling (et/No reader found), IB-4538

### DIFF
--- a/src/translations/et.ts
+++ b/src/translations/et.ts
@@ -181,7 +181,7 @@ Uue PUK koodi saamiseks, külasta klienditeeninduspunkti, kust saad koodiümbrik
     </message>
     <message>
         <source>No reader found</source>
-        <translation>Ühtegi kiipkaardi lugejat pole ühendatud</translation>
+        <translation>Ühtegi kiipkaardilugejat pole ühendatud</translation>
     </message>
     <message>
         <source>Certificates</source>


### PR DESCRIPTION
Text "Ühtegi kiipkaardi lugejat pole ühendatud" changed to "Ühtegi kiipkaardilugejat pole ühendatud"