### PR TITLE
Do not capitalize names/birthplace read from card

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -929,8 +929,8 @@ void MainWindow::updateData()
 		d->changePukStack->setCurrentIndex( t.isPinpad() );
 
 		QStringList name = QStringList()
-			<< SslCertificate::formatName( t.data( QSmartCardData::FirstName1 ).toString() )
-			<< SslCertificate::formatName( t.data( QSmartCardData::FirstName2 ).toString() );
+			<< t.data( QSmartCardData::FirstName1 ).toString()
+			<< t.data( QSmartCardData::FirstName2 ).toString();
 		name.removeAll( "" );
 		d->personalName->setText( name.join(" ") );
 		d->surName->setText( t.data( QSmartCardData::SurName ).toString() );

--- a/src/QSmartCard.cpp
+++ b/src/QSmartCard.cpp
@@ -500,12 +500,6 @@ void QSmartCard::run()
 								record.clear();
 							switch(data)
 							{
-							case QSmartCardData::SurName:
-							case QSmartCardData::FirstName1:
-							case QSmartCardData::FirstName2:
-							case QSmartCardData::BirthPlace:
-								t->data[QSmartCardData::PersonalDataType(data)] = SslCertificate::formatName(record);
-								break;
 							case QSmartCardData::BirthDate:
 							case QSmartCardData::Expiry:
 							case QSmartCardData::IssueDate:


### PR DESCRIPTION
IB-4547: Do not try to format/capitalize names and birthplace in UI, use "as-is" because names
are not always capitalized uniformly (e.g. compound names with particles like Mac, Mc, von etc).
Signed-off-by: Toomas Uudisaru <toomas.uudisaru@aktors.ee>