### PR TITLE
Option to enable SHA1 certificate update

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1009,7 +1009,11 @@ void MainWindow::updateData()
 					!t.authCert().validateEncoding() ||
 					!t.signCert().validateEncoding() ||
 					t.version() & QSmartCardData::VER_HASUPDATER ||
-					t.version() == QSmartCardData::VER_USABLEUPDATER
+					t.version() == QSmartCardData::VER_USABLEUPDATER ||
+					(Configuration::instance().object().contains("EIDUPDATER-SHA1") && (
+						t.authCert().signatureAlgorithm() == "sha1WithRSAEncryption" ||
+						t.signCert().signatureAlgorithm() == "sha1WithRSAEncryption")
+					)
 				)
 			)
 		);


### PR DESCRIPTION
Enable certificate update when central configuration contains key "EIDUPDATER-SHA1" and certificate has signatureAlgorithm "sha1WithRSAEncryption"

Signed-off-by: Raul Metsma <raul@metsma.ee>