### PR TITLE
PUK code validation failure should not block PIN codes

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -161,6 +161,7 @@ void MainWindowPrivate::showWarning( const QString &msg, const QString &details 
 	QMessageBox d( QMessageBox::Warning, tr("ID-card utility"), msg, QMessageBox::Close, qApp->activeWindow() );
 	d.setWindowModality( Qt::WindowModal );
 	d.setDetailedText(details);
+	d.exec();
 }
 
 void MainWindowPrivate::updateMobileStatusText( const QVariant &data, bool set )
@@ -437,6 +438,7 @@ bool MainWindow::eventFilter(QObject *obj, QEvent *event)
 
 void MainWindow::on_languages_activated( int index )
 {
+	QSmartCardData t = d->smartcard->data();
 	lang = d->languages->itemData( index ).toString();
 	if( lang == "en" ) QLocale::setDefault( QLocale( QLocale::English, QLocale::UnitedKingdom ) );
 	else if( lang == "ru" ) QLocale::setDefault( QLocale( QLocale::Russian, QLocale::RussianFederation ) );
@@ -451,14 +453,58 @@ void MainWindow::on_languages_activated( int index )
 	d->version->setText( windowTitle() + " " + qApp->applicationVersion() );
 
 	if( d->changePin1Info->currentWidget() == d->changePin1InfoPin )
+	{
 		d->changePin1ValidateLabel->setText( tr("Current PIN1 code") );
+		if( !t.isNull() )
+		{
+			d->changePin1AttemptsLable->setText( tr("Attempts left: %1").arg( t.retryCount( QSmartCardData::Pin1Type ) ) );
+			d->changePin1AttemptsLable->setVisible( t.retryCount( QSmartCardData::Pin1Type ) < THREE_ATTEMPTS );
+			d->changePin1PinpadAttemptsLable->setText( tr("Attempts left: %1").arg( t.retryCount( QSmartCardData::Pin1Type ) ) );
+			d->changePin1PinpadAttemptsLable->setVisible( t.retryCount( QSmartCardData::Pin1Type ) < THREE_ATTEMPTS );
+		}
+	}
 	else
+	{
 		d->changePin1ValidateLabel->setText( tr("Current PUK code") );
+		if( !t.isNull() )
+		{
+			d->changePin1AttemptsLable->setText( tr("Attempts left: %1").arg( t.retryCount( QSmartCardData::PukType ) ) );
+			d->changePin1AttemptsLable->setVisible( t.retryCount( QSmartCardData::PukType ) < THREE_ATTEMPTS );
+			d->changePin1PinpadAttemptsLable->setText( tr("Attempts left: %1").arg( t.retryCount( QSmartCardData::PukType ) ) );
+			d->changePin1PinpadAttemptsLable->setVisible( t.retryCount( QSmartCardData::PukType ) < THREE_ATTEMPTS );
+		}
+	}
+	if( d->changePin1Info->currentWidget() == d->changePin1InfoUnblock )
+		d->changePin1Change->setText( tr("Unblock") );
+	else
+		d->changePin1Change->setText( tr("Change") );
 
 	if( d->changePin2Info->currentWidget() == d->changePin2InfoPin )
+	{
 		d->changePin2ValidateLabel->setText( tr("Current PIN2 code") );
+		if( !t.isNull() )
+		{
+			d->changePin2AttemptsLable->setText( tr("Attempts left: %1").arg( t.retryCount( QSmartCardData::Pin2Type ) ) );
+			d->changePin2AttemptsLable->setVisible( t.retryCount( QSmartCardData::Pin2Type ) < THREE_ATTEMPTS );
+			d->changePin2PinpadAttemptsLable->setText( tr("Attempts left: %1").arg( t.retryCount( QSmartCardData::Pin2Type ) ) );
+			d->changePin2PinpadAttemptsLable->setVisible( t.retryCount( QSmartCardData::Pin2Type ) < THREE_ATTEMPTS );
+		}
+	}
 	else
+	{
 		d->changePin2ValidateLabel->setText( tr("Current PUK code") );
+		if( !t.isNull() )
+		{
+			d->changePin2AttemptsLable->setText( tr("Attempts left: %1").arg( t.retryCount( QSmartCardData::PukType ) ) );
+			d->changePin2AttemptsLable->setVisible( t.retryCount( QSmartCardData::PukType ) < THREE_ATTEMPTS );
+			d->changePin2PinpadAttemptsLable->setText( tr("Attempts left: %1").arg( t.retryCount( QSmartCardData::PukType) ) );
+			d->changePin2PinpadAttemptsLable->setVisible( t.retryCount( QSmartCardData::PukType ) < THREE_ATTEMPTS );
+		}
+	}
+	if( d->changePin2Info->currentWidget() == d->changePin2InfoUnblock )
+		d->changePin2Change->setText( tr("Unblock") );
+	else
+		d->changePin2Change->setText( tr("Change") );
 
 	updateData();
 	d->updateMobileStatusText( QVariant(), false );
@@ -675,6 +721,10 @@ void MainWindow::setDataPage( int index )
 		d->changePin1Info->setCurrentWidget( d->changePin1InfoPin );
 		d->changePin1PinpadInfo->setCurrentWidget( d->changePin1PinpadInfoPin );
 		d->changePin1ValidateLabel->setText( tr("Current PIN1 code") );
+		d->changePin1AttemptsLable->setText( tr("Attempts left: %1").arg( t.retryCount( QSmartCardData::Pin1Type ) ) );
+		d->changePin1AttemptsLable->setVisible( t.retryCount( QSmartCardData::Pin1Type ) < THREE_ATTEMPTS );
+		d->changePin1PinpadAttemptsLable->setText( tr("Attempts left: %1").arg( t.retryCount( QSmartCardData::Pin1Type ) ) );
+		d->changePin1PinpadAttemptsLable->setVisible( t.retryCount( QSmartCardData::Pin1Type ) < THREE_ATTEMPTS );
 		d->changePin1Validate->setFocus();
 		d->changePin1Change->setText( tr("Change") );
 		d->changePin1PinpadChange->setText( tr("Change with PinPad") );
@@ -685,6 +735,10 @@ void MainWindow::setDataPage( int index )
 		d->changePin1Info->setCurrentWidget( d->changePin1InfoPuk );
 		d->changePin1PinpadInfo->setCurrentWidget( d->changePin1PinpadInfoPuk );
 		d->changePin1ValidateLabel->setText( tr("Current PUK code") );
+		d->changePin1AttemptsLable->setText( tr("Attempts left: %1").arg( t.retryCount( QSmartCardData::PukType ) ) );
+		d->changePin1AttemptsLable->setVisible( t.retryCount( QSmartCardData::PukType ) < THREE_ATTEMPTS );
+		d->changePin1PinpadAttemptsLable->setText( tr("Attempts left: %1").arg( t.retryCount( QSmartCardData::PukType ) ) );
+		d->changePin1PinpadAttemptsLable->setVisible( t.retryCount( QSmartCardData::PukType ) < THREE_ATTEMPTS );
 		d->changePin1Validate->setFocus();
 		d->changePin1Change->setText( tr("Change") );
 		d->changePin1PinpadChange->setText( tr("Change with PinPad") );
@@ -695,6 +749,10 @@ void MainWindow::setDataPage( int index )
 		d->changePin1Info->setCurrentWidget( d->changePin1InfoUnblock );
 		d->changePin1PinpadInfo->setCurrentWidget( d->changePin1PinpadInfoUnblock );
 		d->changePin1ValidateLabel->setText( tr("Current PUK code") );
+		d->changePin1AttemptsLable->setText( tr("Attempts left: %1").arg( t.retryCount( QSmartCardData::PukType ) ) );
+		d->changePin1AttemptsLable->setVisible( t.retryCount( QSmartCardData::PukType ) < THREE_ATTEMPTS );
+		d->changePin1PinpadAttemptsLable->setText( tr("Attempts left: %1").arg( t.retryCount( QSmartCardData::PukType ) ) );
+		d->changePin1PinpadAttemptsLable->setVisible( t.retryCount( QSmartCardData::PukType ) < THREE_ATTEMPTS );
 		d->changePin1Validate->setFocus();
 		d->changePin1Change->setText( tr("Unblock") );
 		d->changePin1PinpadChange->setText( tr("Unblock with PinPad") );
@@ -751,12 +809,24 @@ void MainWindow::setDataPage( int index )
 			updateData();
 			setDataPage( PageCert );
 		}
+		else
+		{
+			t = d->smartcard->data();	// refresh modified object's data
+			d->changePin1AttemptsLable->setText( tr("Attempts left: %1").arg( t.retryCount( QSmartCardData::PukType ) ) );
+			d->changePin1AttemptsLable->setVisible( t.retryCount( QSmartCardData::PukType ) < THREE_ATTEMPTS );
+			d->changePin1PinpadAttemptsLable->setText( tr("Attempts left: %1").arg( t.retryCount( QSmartCardData::PukType ) ) );
+			d->changePin1PinpadAttemptsLable->setVisible( t.retryCount( QSmartCardData::PukType ) < THREE_ATTEMPTS );
+		}
 		d->clearPins();
 		break;
 	case PagePin2Pin:
 		d->changePin2Info->setCurrentWidget( d->changePin2InfoPin );
 		d->changePin2PinpadInfo->setCurrentWidget( d->changePin2PinpadInfoPin );
 		d->changePin2ValidateLabel->setText( tr("Current PIN2 code") );
+		d->changePin2AttemptsLable->setText( tr("Attempts left: %1").arg( t.retryCount( QSmartCardData::Pin2Type ) ) );
+		d->changePin2AttemptsLable->setVisible( t.retryCount( QSmartCardData::Pin2Type ) < THREE_ATTEMPTS );
+		d->changePin2PinpadAttemptsLable->setText( tr("Attempts left: %1").arg( t.retryCount( QSmartCardData::Pin2Type ) ) );
+		d->changePin2PinpadAttemptsLable->setVisible( t.retryCount( QSmartCardData::Pin2Type ) < THREE_ATTEMPTS );
 		d->changePin2Validate->setFocus();
 		d->changePin2Change->setText( tr("Change") );
 		d->changePin2PinpadChange->setText( tr("Change with PinPad") );
@@ -767,6 +837,10 @@ void MainWindow::setDataPage( int index )
 		d->changePin2Info->setCurrentWidget( d->changePin2InfoPuk );
 		d->changePin2PinpadInfo->setCurrentWidget( d->changePin2PinpadInfoPuk );
 		d->changePin2ValidateLabel->setText( tr("Current PUK code") );
+		d->changePin2AttemptsLable->setText( tr("Attempts left: %1").arg( t.retryCount( QSmartCardData::PukType ) ) );
+		d->changePin2AttemptsLable->setVisible( t.retryCount( QSmartCardData::PukType ) < THREE_ATTEMPTS );
+		d->changePin2PinpadAttemptsLable->setText( tr("Attempts left: %1").arg( t.retryCount( QSmartCardData::PukType ) ) );
+		d->changePin2PinpadAttemptsLable->setVisible( t.retryCount( QSmartCardData::PukType ) < THREE_ATTEMPTS );
 		d->changePin2Validate->setFocus();
 		d->changePin2Change->setText( tr("Change") );
 		d->changePin2PinpadChange->setText( tr("Change with PinPad") );
@@ -777,6 +851,10 @@ void MainWindow::setDataPage( int index )
 		d->changePin2Info->setCurrentWidget( d->changePin2InfoUnblock );
 		d->changePin2PinpadInfo->setCurrentWidget( d->changePin2PinpadInfoUnblock );
 		d->changePin2ValidateLabel->setText( tr("Current PUK code") );
+		d->changePin2AttemptsLable->setText( tr("Attempts left: %1").arg( t.retryCount( QSmartCardData::PukType ) ) );
+		d->changePin2AttemptsLable->setVisible( t.retryCount( QSmartCardData::PukType ) < THREE_ATTEMPTS );
+		d->changePin2PinpadAttemptsLable->setText( tr("Attempts left: %1").arg( t.retryCount( QSmartCardData::PukType ) ) );
+		d->changePin2PinpadAttemptsLable->setVisible( t.retryCount( QSmartCardData::PukType ) < THREE_ATTEMPTS );
 		d->changePin2Validate->setFocus();
 		d->changePin2Change->setText( tr("Unblock") );
 		d->changePin2PinpadChange->setText( tr("Unblock with PinPad") );
@@ -833,10 +911,22 @@ void MainWindow::setDataPage( int index )
 			updateData();
 			setDataPage( PageCert );
 		}
+		else
+		{
+			t = d->smartcard->data();	// refresh modified object's data
+			d->changePin2AttemptsLable->setText( tr("Attempts left: %1").arg( t.retryCount( QSmartCardData::PukType ) ) );
+			d->changePin2AttemptsLable->setVisible( t.retryCount( QSmartCardData::PukType ) < THREE_ATTEMPTS );
+			d->changePin2PinpadAttemptsLable->setText( tr("Attempts left: %1").arg( t.retryCount( QSmartCardData::PukType ) ) );
+			d->changePin2PinpadAttemptsLable->setVisible( t.retryCount( QSmartCardData::PukType ) < THREE_ATTEMPTS );
+		}
 		d->clearPins();
 		break;
 	case PagePuk:
 		d->changePukValidate->setFocus();
+		d->changePukAttemptsLable->setText( tr("Attempts left: %1").arg( t.retryCount( QSmartCardData::PukType ) ) );
+		d->changePukAttemptsLable->setVisible( t.retryCount( QSmartCardData::PukType ) < THREE_ATTEMPTS );
+		d->changePukPinpadAttemptsLable->setText( tr("Attempts left: %1").arg( t.retryCount( QSmartCardData::PukType ) ) );
+		d->changePukPinpadAttemptsLable->setVisible( t.retryCount( QSmartCardData::PukType ) < THREE_ATTEMPTS );
 		break;
 	case PagePukChange:
 		if( !t.isPinpad() && !d->validatePin( QSmartCardData::PukType, false,
@@ -975,6 +1065,29 @@ void MainWindow::updateData()
 			tr("Certificate will expire in %1 days").arg( signDays ) : tr("Certificate is expired") );
 		d->authCertExpired->setVisible( authDays <= 105 && t.retryCount( QSmartCardData::Pin1Type ) != 0 );
 		d->signCertExpired->setVisible( signDays <= 105 && t.retryCount( QSmartCardData::Pin2Type ) != 0 );
+
+		if( d->changePin1Info->currentWidget() == d->changePin1InfoPin )
+		{
+			d->changePin1AttemptsLable->setText( tr("Attempts left: %1").arg( t.retryCount( QSmartCardData::Pin1Type ) ) );
+			d->changePin1AttemptsLable->setVisible( t.retryCount( QSmartCardData::Pin1Type ) < THREE_ATTEMPTS );
+			d->changePin1PinpadAttemptsLable->setText( tr("Attempts left: %1").arg( t.retryCount( QSmartCardData::Pin1Type ) ) );
+			d->changePin1PinpadAttemptsLable->setVisible( t.retryCount( QSmartCardData::Pin1Type ) < THREE_ATTEMPTS );
+		}
+		if( d->changePin2Info->currentWidget() == d->changePin2InfoPin )
+		{
+			d->changePin2AttemptsLable->setText( tr("Attempts left: %1").arg( t.retryCount( QSmartCardData::Pin2Type ) ) );
+			d->changePin2AttemptsLable->setVisible( t.retryCount( QSmartCardData::Pin2Type ) < THREE_ATTEMPTS );
+			d->changePin2PinpadAttemptsLable->setText( tr("Attempts left: %1").arg( t.retryCount( QSmartCardData::Pin2Type ) ) );
+			d->changePin2PinpadAttemptsLable->setVisible( t.retryCount( QSmartCardData::Pin2Type ) < THREE_ATTEMPTS );
+		}
+		if( ( d->changePin1Info->currentWidget() != d->changePin1InfoPin ) &&
+			( d->changePin2Info->currentWidget() != d->changePin2InfoPin ) )
+		{
+			d->changePukAttemptsLable->setText( tr("Attempts left: %1").arg( t.retryCount( QSmartCardData::PukType ) ) );
+			d->changePukAttemptsLable->setVisible( t.retryCount( QSmartCardData::PukType ) < THREE_ATTEMPTS );
+			d->changePukPinpadAttemptsLable->setText( tr("Attempts left: %1").arg( t.retryCount( QSmartCardData::PukType ) ) );
+			d->changePukPinpadAttemptsLable->setVisible( t.retryCount( QSmartCardData::PukType ) < THREE_ATTEMPTS );
+		}
 
 		d->authChangePin->setVisible( t.retryCount( QSmartCardData::Pin1Type ) > 0 );
 		d->signChangePin->setVisible( t.retryCount( QSmartCardData::Pin2Type ) > 0 );

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -21,6 +21,8 @@
 
 #include <QtWidgets/QWidget>
 
+#define THREE_ATTEMPTS	3		// user has three attempts to enter a correct PIN1/PIN2/PUK code
+
 class MainWindowPrivate;
 
 class MainWindow: public QWidget

--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -147,7 +147,7 @@ padding-bottom: 5px;
 
 #authTill, #signTill { color: black; font-weight: bold;  }
 #authValidity, #signValidity { color: #509b00; font-weight: bold; }
-#authInValidity, #signInValidity, #authCertExpired, #signCertExpired, #pukLocked { color: #e80303; font-weight: bold; }
+#authInValidity, #signInValidity, #authCertExpired, #changePin1AttemptsLable, #changePin2AttemptsLable, #changePukAttemptsLable, #changePin1PinpadAttemptsLable, #changePin2PinpadAttemptsLable, #changePukPinpadAttemptsLable, #signCertExpired, #pukLocked { color: #e80303; font-weight: bold; }
 #authCertBlocked, #signCertBlocked {
 font-size: 14px;
 font-weight: bold;
@@ -685,7 +685,7 @@ border-radius: 10px;
       <item row="4" column="0" colspan="2">
        <widget class="QStackedWidget" name="dataWidget">
         <property name="currentIndex">
-         <number>0</number>
+         <number>6</number>
         </property>
         <widget class="QLabel" name="pageEmpty">
          <property name="pixmap">
@@ -1639,7 +1639,7 @@ Please visit the service center to obtain new codes. &lt;a href=&quot;http://www
           <item>
            <widget class="QStackedWidget" name="changePin1Stack">
             <property name="currentIndex">
-             <number>0</number>
+             <number>1</number>
             </property>
             <widget class="QWidget" name="changePin1Reader">
              <layout class="QGridLayout" name="changePin1ReaderLayout">
@@ -1658,16 +1658,6 @@ Please visit the service center to obtain new codes. &lt;a href=&quot;http://www
               <property name="spacing">
                <number>5</number>
               </property>
-              <item row="0" column="0" colspan="3">
-               <widget class="QLabel" name="changePin1ValidateLabel">
-                <property name="text">
-                 <string>Current PIN1 code</string>
-                </property>
-                <property name="buddy">
-                 <cstring>changePin1Validate</cstring>
-                </property>
-               </widget>
-              </item>
               <item row="1" column="0" colspan="3">
                <widget class="QLineEdit" name="changePin1Validate">
                 <property name="maxLength">
@@ -1763,6 +1753,23 @@ Please visit the service center to obtain new codes. &lt;a href=&quot;http://www
                 </property>
                </spacer>
               </item>
+              <item row="0" column="0">
+               <widget class="QLabel" name="changePin1ValidateLabel">
+                <property name="text">
+                 <string>Current PIN1 code</string>
+                </property>
+                <property name="buddy">
+                 <cstring>changePin1Validate</cstring>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="1" colspan="2">
+               <widget class="QLabel" name="changePin1AttemptsLable">
+                <property name="text">
+                 <string>Attempts left: %1</string>
+                </property>
+               </widget>
+              </item>
              </layout>
             </widget>
             <widget class="QWidget" name="changePin1Pinpad">
@@ -1779,7 +1786,30 @@ Please visit the service center to obtain new codes. &lt;a href=&quot;http://www
               <property name="bottomMargin">
                <number>0</number>
               </property>
-              <item row="0" column="0" colspan="3">
+              <item row="2" column="1">
+               <widget class="QPushButton" name="changePin1PinpadCancel">
+                <property name="text">
+                 <string>Cancel</string>
+                </property>
+                <property name="flat">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="2">
+               <spacer name="changePin1PinpadSpacer">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>96</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+              <item row="1" column="0" colspan="3">
                <widget class="QStackedWidget" name="changePin1PinpadInfo">
                 <widget class="QLabel" name="changePin1PinpadInfoPin">
                  <property name="text">
@@ -1807,7 +1837,7 @@ Please visit the service center to obtain new codes. &lt;a href=&quot;http://www
                 </widget>
                </widget>
               </item>
-              <item row="1" column="0">
+              <item row="2" column="0">
                <widget class="QPushButton" name="changePin1PinpadChange">
                 <property name="text">
                  <string>Change with PinPad</string>
@@ -1817,28 +1847,12 @@ Please visit the service center to obtain new codes. &lt;a href=&quot;http://www
                 </property>
                </widget>
               </item>
-              <item row="1" column="1">
-               <widget class="QPushButton" name="changePin1PinpadCancel">
+              <item row="0" column="0">
+               <widget class="QLabel" name="changePin1PinpadAttemptsLable">
                 <property name="text">
-                 <string>Cancel</string>
-                </property>
-                <property name="flat">
-                 <bool>true</bool>
+                 <string>Attempts left: %1</string>
                 </property>
                </widget>
-              </item>
-              <item row="1" column="2">
-               <spacer name="changePin1PinpadSpacer">
-                <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>96</width>
-                  <height>20</height>
-                 </size>
-                </property>
-               </spacer>
               </item>
              </layout>
             </widget>
@@ -1960,7 +1974,7 @@ Please visit the service center to obtain new codes. &lt;a href=&quot;http://www
           <item>
            <widget class="QStackedWidget" name="changePin2Stack">
             <property name="currentIndex">
-             <number>0</number>
+             <number>1</number>
             </property>
             <widget class="QWidget" name="changePin2Reader">
              <layout class="QGridLayout" name="changePin2ReaderLayout">
@@ -1979,16 +1993,6 @@ Please visit the service center to obtain new codes. &lt;a href=&quot;http://www
               <property name="spacing">
                <number>5</number>
               </property>
-              <item row="0" column="0" colspan="3">
-               <widget class="QLabel" name="changePin2ValidateLabel">
-                <property name="text">
-                 <string>Current PIN2 code</string>
-                </property>
-                <property name="buddy">
-                 <cstring>changePin2Validate</cstring>
-                </property>
-               </widget>
-              </item>
               <item row="1" column="0" colspan="3">
                <widget class="QLineEdit" name="changePin2Validate">
                 <property name="maxLength">
@@ -2084,6 +2088,23 @@ Please visit the service center to obtain new codes. &lt;a href=&quot;http://www
                 </property>
                </spacer>
               </item>
+              <item row="0" column="0">
+               <widget class="QLabel" name="changePin2ValidateLabel">
+                <property name="text">
+                 <string>Current PIN2 code</string>
+                </property>
+                <property name="buddy">
+                 <cstring>changePin2Validate</cstring>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="1" colspan="2">
+               <widget class="QLabel" name="changePin2AttemptsLable">
+                <property name="text">
+                 <string>Attempts left: %1</string>
+                </property>
+               </widget>
+              </item>
              </layout>
             </widget>
             <widget class="QWidget" name="changePin2Pinpad">
@@ -2100,8 +2121,11 @@ Please visit the service center to obtain new codes. &lt;a href=&quot;http://www
               <property name="bottomMargin">
                <number>0</number>
               </property>
-              <item row="0" column="0" colspan="3">
+              <item row="1" column="0" colspan="3">
                <widget class="QStackedWidget" name="changePin2PinpadInfo">
+                <property name="currentIndex">
+                 <number>0</number>
+                </property>
                 <widget class="QLabel" name="changePin2PinpadInfoPin">
                  <property name="text">
                   <string>To change PIN code on PinPad reader old PIN code have to be entered first and then new PIN code twice.</string>
@@ -2128,17 +2152,7 @@ Please visit the service center to obtain new codes. &lt;a href=&quot;http://www
                 </widget>
                </widget>
               </item>
-              <item row="1" column="0">
-               <widget class="QPushButton" name="changePin2PinpadChange">
-                <property name="text">
-                 <string>Change with PinPad</string>
-                </property>
-                <property name="flat">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="1">
+              <item row="2" column="1">
                <widget class="QPushButton" name="changePin2PinpadCancel">
                 <property name="text">
                  <string>Cancel</string>
@@ -2148,7 +2162,7 @@ Please visit the service center to obtain new codes. &lt;a href=&quot;http://www
                 </property>
                </widget>
               </item>
-              <item row="1" column="2">
+              <item row="2" column="2">
                <spacer name="changePin2PinpadSpacer">
                 <property name="orientation">
                  <enum>Qt::Horizontal</enum>
@@ -2160,6 +2174,23 @@ Please visit the service center to obtain new codes. &lt;a href=&quot;http://www
                  </size>
                 </property>
                </spacer>
+              </item>
+              <item row="2" column="0">
+               <widget class="QPushButton" name="changePin2PinpadChange">
+                <property name="text">
+                 <string>Change with PinPad</string>
+                </property>
+                <property name="flat">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="0">
+               <widget class="QLabel" name="changePin2PinpadAttemptsLable">
+                <property name="text">
+                 <string>Attempts left: %1</string>
+                </property>
+               </widget>
               </item>
              </layout>
             </widget>
@@ -2236,16 +2267,6 @@ Please visit the service center to obtain new codes. &lt;a href=&quot;http://www
               <property name="spacing">
                <number>5</number>
               </property>
-              <item row="0" column="0" colspan="3">
-               <widget class="QLabel" name="changePukValidateLabel">
-                <property name="text">
-                 <string>Current PUK code</string>
-                </property>
-                <property name="buddy">
-                 <cstring>changePukValidate</cstring>
-                </property>
-               </widget>
-              </item>
               <item row="1" column="0" colspan="3">
                <widget class="QLineEdit" name="changePukValidate">
                 <property name="maxLength">
@@ -2341,6 +2362,23 @@ Please visit the service center to obtain new codes. &lt;a href=&quot;http://www
                 </property>
                </spacer>
               </item>
+              <item row="0" column="0">
+               <widget class="QLabel" name="changePukValidateLabel">
+                <property name="text">
+                 <string>Current PUK code</string>
+                </property>
+                <property name="buddy">
+                 <cstring>changePukValidate</cstring>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="1" colspan="2">
+               <widget class="QLabel" name="changePukAttemptsLable">
+                <property name="text">
+                 <string>Attempts left: %1</string>
+                </property>
+               </widget>
+              </item>
              </layout>
             </widget>
             <widget class="QWidget" name="changePukPinpad">
@@ -2357,7 +2395,7 @@ Please visit the service center to obtain new codes. &lt;a href=&quot;http://www
               <property name="bottomMargin">
                <number>0</number>
               </property>
-              <item row="0" column="0" colspan="3">
+              <item row="1" column="0" colspan="3">
                <widget class="QLabel" name="changePukPinpadInfo">
                 <property name="text">
                  <string>To change the PUK code on a PinPad reader the old PUK code has to be entered first and then the new PUK code twice.</string>
@@ -2367,27 +2405,7 @@ Please visit the service center to obtain new codes. &lt;a href=&quot;http://www
                 </property>
                </widget>
               </item>
-              <item row="1" column="0">
-               <widget class="QPushButton" name="changePukPinpadChange">
-                <property name="text">
-                 <string>Change with PinPad</string>
-                </property>
-                <property name="flat">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="1">
-               <widget class="QPushButton" name="changePukPinpadCancel">
-                <property name="text">
-                 <string>Cancel</string>
-                </property>
-                <property name="flat">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="2">
+              <item row="2" column="2">
                <spacer name="changePukPinpadSpacer">
                 <property name="orientation">
                  <enum>Qt::Horizontal</enum>
@@ -2399,6 +2417,33 @@ Please visit the service center to obtain new codes. &lt;a href=&quot;http://www
                  </size>
                 </property>
                </spacer>
+              </item>
+              <item row="2" column="0">
+               <widget class="QPushButton" name="changePukPinpadChange">
+                <property name="text">
+                 <string>Change with PinPad</string>
+                </property>
+                <property name="flat">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="1">
+               <widget class="QPushButton" name="changePukPinpadCancel">
+                <property name="text">
+                 <string>Cancel</string>
+                </property>
+                <property name="flat">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="0" colspan="3">
+               <widget class="QLabel" name="changePukPinpadAttemptsLable">
+                <property name="text">
+                 <string>Attempts left: %1</string>
+                </property>
+               </widget>
               </item>
              </layout>
             </widget>

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -672,6 +672,10 @@ Updating takes ca 2-10 minutes and requires an active internet connection. Do no
         <translation>&lt;b&gt;Your ID card certificates need to be updated.&lt;/b&gt;&lt;br/&gt;
 Updating takes ca 2-10 minutes and requires an active internet connection. Do not remove the ID card from the smartcard reader until the update is complete.</translation>
     </message>
+    <message>
+        <source>Attempts left: %1</source>
+        <translation>Attempts left: %1</translation>
+    </message>
 </context>
 <context>
     <name>SSLConnect</name>

--- a/src/translations/et.ts
+++ b/src/translations/et.ts
@@ -672,6 +672,10 @@ Updating takes ca 2-10 minutes and requires an active internet connection. Do no
         <translation>&lt;b&gt;Kaardi sertifikaadid vajavad uuendamist.&lt;/b&gt;&lt;br/&gt;
 Uuendamise protseduur võtab aega 2-10 minutit ning eeldab toimivat internetiühendust. Kaarti ei tohi lugejast välja võtta enne uuenduse lõppu.</translation>
     </message>
+    <message>
+        <source>Attempts left: %1</source>
+        <translation>Katseid jäänud: %1</translation>
+    </message>
 </context>
 <context>
     <name>SSLConnect</name>

--- a/src/translations/ru.ts
+++ b/src/translations/ru.ts
@@ -205,7 +205,7 @@ Please visit the service center to obtain new codes. &lt;a href=&quot;http://www
     </message>
     <message>
         <source>Loading data</source>
-        <translation type="unfinished"></translation>
+        <translation>Загрузка данных</translation>
     </message>
     <message>
         <source>Failed activating email forwards.</source>
@@ -387,7 +387,7 @@ Please visit the service center to obtain new codes. &lt;a href=&quot;http://www
     </message>
     <message>
         <source>Failed to load data</source>
-        <translation type="unfinished"></translation>
+        <translation>Данные загрузить не получилось></translation>
     </message>
     <message>
         <source>Enter PIN/PUK codes on PinPad</source>
@@ -523,11 +523,11 @@ Please visit the service center to obtain new codes. &lt;a href=&quot;http://www
     </message>
     <message>
         <source>Cards</source>
-        <translation type="unfinished"></translation>
+        <translation>Карты></translation>
     </message>
     <message>
         <source>Languages</source>
-        <translation type="unfinished"></translation>
+        <translation>Языки></translation>
     </message>
     <message>
         <source>Mobiil-ID is the possibility to use a mobile phone instead of an ID-card for identification and digital signing.&lt;br /&gt;More info from &lt;a href=&quot;http://mobiil.id.ee&quot;&gt;mobiil.id.ee&lt;/a&gt;&lt;br /&gt;&lt;br /&gt;
@@ -546,11 +546,11 @@ To use Mobiil-ID a SIM card that supports this feature has to be used. If such a
     </message>
     <message>
         <source>Personal info</source>
-        <translation type="unfinished"></translation>
+        <translation>Данные файла</translation>
     </message>
     <message>
         <source>Card info</source>
-        <translation type="unfinished"></translation>
+        <translation>Данные карты</translation>
     </message>
     <message>
         <source>You&apos;re using Digital identity card</source>
@@ -558,7 +558,7 @@ To use Mobiil-ID a SIM card that supports this feature has to be used. If such a
     </message>
     <message>
         <source>Picture</source>
-        <translation type="unfinished"></translation>
+        <translation>Фотография</translation>
     </message>
     <message>
         <source>Change PIN1 using PUK code</source>
@@ -674,6 +674,10 @@ Updating takes ca 2-10 minutes and requires an active internet connection. Do no
         <translation>&lt;b&gt;Сертификаты Вашей ID-карты необходимо обновить.&lt;/b&gt;&lt;br/&gt;
 Обновление занимает около 2-10 минут и требует наличия интернет-соединения. Не извлекайте ID-карту из считывающего устройства до завершения процесса обновления.</translation>
     </message>
+    <message>
+        <source>Attempts left: %1</source>
+        <translation>Осталось попыток: %1</translation>
+    </message>
 </context>
 <context>
     <name>SSLConnect</name>
@@ -699,7 +703,7 @@ Updating takes ca 2-10 minutes and requires an active internet connection. Do no
     </message>
     <message>
         <source>Certificate is empty</source>
-        <translation type="unfinished"></translation>
+        <translation>Сертификат пустой</translation>
     </message>
     <message>
         <source>Invalid reponse</source>


### PR DESCRIPTION
IB-4717:
   1. Do not validate PUK code for PINPAD.
   2. PUK code validation failure should not block PIN codes (this is not checked for PINPAD).
   3. Added 'Attempts left: ...' warning text (in bold, red colour), which is shown in dialog when user has less than three attempts to enter either PIN1 or PIN2 or PUK codes.
   4. Fixed 'Unblock' button translation issue, when changing the UI language.

Dead code removal.

1. Dead code is removed.
2. Re-read the modified object's data (when it was changed), to be able to show the correct
number of left attempts.

To be tested the process of unblocking PIN1/2 or changing PIN1/2 with PUK code:
   1. PINPAD PUK validation is removed. This should be tested somehow on working PINPAD.
   2. Note that if PUK validation fails 3 times then ID card is locked!

Signed-off-by: Oleg Prokofjev <oleg@aktors.ee>