### PR TITLE
Add LibreSSL support

### DIFF
--- a/src/QSmartCard.cpp
+++ b/src/QSmartCard.cpp
@@ -212,7 +212,7 @@ QSmartCard::QSmartCard(QObject *parent)
 :	QThread(parent)
 ,	d(new QSmartCardPrivate)
 {
-#if OPENSSL_VERSION_NUMBER < 0x10010000L
+#if OPENSSL_VERSION_NUMBER < 0x10010000L || defined(LIBRESSL_VERSION_NUMBER)
 	d->method.name = "QSmartCard";
 	d->method.rsa_sign = QSmartCardPrivate::rsa_sign;
 #else
@@ -271,7 +271,7 @@ Qt::HANDLE QSmartCard::key()
 	if (!rsa)
 		return 0;
 
-#if OPENSSL_VERSION_NUMBER < 0x10010000L
+#if OPENSSL_VERSION_NUMBER < 0x10010000L || defined(LIBRESSL_VERSION_NUMBER)
 	RSA_set_method(rsa, &d->method);
 	rsa->flags |= RSA_FLAG_SIGN_VER;
 #else

--- a/src/QSmartCard_p.h
+++ b/src/QSmartCard_p.h
@@ -47,7 +47,7 @@ public:
 	QMutex			m;
 	QSmartCardData	t;
 	volatile bool	terminate = false;
-#if OPENSSL_VERSION_NUMBER < 0x10010000L
+#if OPENSSL_VERSION_NUMBER < 0x10010000L || defined(LIBRESSL_VERSION_NUMBER)
 	RSA_METHOD		method = *RSA_get_default_method();
 #else
 	RSA_METHOD		*method = RSA_meth_dup(RSA_get_default_method());

--- a/src/Updater.cpp
+++ b/src/Updater.cpp
@@ -52,7 +52,7 @@ class UpdaterPrivate: public Ui::Updater
 public:
 	QPCSCReader *reader = nullptr;
 	QPushButton *close = nullptr, *details = nullptr;
-#if OPENSSL_VERSION_NUMBER < 0x10010000L
+#if OPENSSL_VERSION_NUMBER < 0x10010000L || defined(LIBRESSL_VERSION_NUMBER)
 	RSA_METHOD method = *RSA_get_default_method();
 #else
 	RSA_METHOD *method = RSA_meth_dup(RSA_get_default_method());
@@ -225,7 +225,7 @@ Updater::Updater(const QString &reader, QWidget *parent)
 
 	d->reader = new QPCSCReader(reader, &QPCSC::instance());
 
-#if OPENSSL_VERSION_NUMBER < 0x10010000L
+#if OPENSSL_VERSION_NUMBER < 0x10010000L || defined(LIBRESSL_VERSION_NUMBER)
 	d->method.name = "Updater";
 	d->method.rsa_sign = UpdaterPrivate::rsa_sign;
 #else
@@ -452,7 +452,7 @@ int Updater::exec()
 	if(!d->cert.isNull())
 	{
 		RSA *rsa = RSAPublicKey_dup((RSA*)d->cert.publicKey().handle());
-#if OPENSSL_VERSION_NUMBER < 0x10010000L
+#if OPENSSL_VERSION_NUMBER < 0x10010000L || defined(LIBRESSL_VERSION_NUMBER)
 		RSA_set_method(rsa, &d->method);
 		rsa->flags |= RSA_FLAG_SIGN_VER;
 #else


### PR DESCRIPTION
LibreSSL's API is pretty much OpenSSL's as of late 2014, minus legacy
architecture support code and with added focus on Security.

Hence adding defined(LIBRESSL_VERSION_NUMBER) to conditionals that check for
having pre-1.1.0 API works.